### PR TITLE
tinyalsa_hal.c: Fix mixer control set value bug

### DIFF
--- a/alsa/tinyalsa_hal.c
+++ b/alsa/tinyalsa_hal.c
@@ -291,8 +291,11 @@ static int set_route_by_array(struct mixer *mixer, struct route_setting *route,
     i = 0;
     while (route[i].ctl_name) {
         ctl = mixer_get_ctl_by_name(mixer, route[i].ctl_name);
-        if (!ctl)
-            return -EINVAL;
+        if (!ctl) {
+            ALOGW("Can't set mixer ctl value for missing control %s", route[i].ctl_name);
+            i++;
+            continue;
+        }
 
         if (route[i].strval) {
             if (enable)


### PR DESCRIPTION
Don't exit on error when setting mixer control values. This allows
default values for all mixer controls to get set.